### PR TITLE
chore: change name of workflow per standard

### DIFF
--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -27,4 +27,4 @@ jobs:
           APP_ID: "${{ secrets.APP_ID }}"
           APP_PRIVATE_KEY: "${{ secrets.APP_PRIVATE_KEY }}"
           TARGET_REPO: "lidofinance/infra-mainnet"
-          TARGET_WORKFLOW: "deploy_staging_aragon_apps.yaml"
+          TARGET_WORKFLOW: "deploy_staging_mainnet_aragon_apps.yaml"


### PR DESCRIPTION
We switched to a new generated workflows, and staging deployment for aragon-apps is now names 'as everyone else', so name changed to `.github/workflows/ci-staging.yml`.

Updating parameters to fix.